### PR TITLE
Restyle layout with grey palette and clean up dead code

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,70 +5,66 @@
 
     {% seo %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#828a8f">
 
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    {% include head-custom.html %}
     <style>
-      /* Base reset and typography */
-      *, *::before, *::after {
-        box-sizing: border-box;
-      }
+      /*
+       * Grey palette — base #828a8f (RGB 130 138 143)
+       *   Tints:  #c1c5c7  #e0e2e3  #f2f3f4
+       *   Shades: #61686b  #414548  #212324
+       */
+
+      *, *::before, *::after { box-sizing: border-box; }
 
       body {
         font-family: "Times New Roman", Times, serif;
-        color: #000000;
-        background-color: #ffffff80;
+        color: #212324;
+        background-color: #f2f3f4;
         margin: 0;
         padding: 0;
         font-size: 16px;
         line-height: 1.7;
       }
 
-      /* All links are blue */
       a {
-        color: #0000cc;
+        color: #414548;
         text-decoration: none;
       }
 
       a:hover {
+        color: #212324;
         text-decoration: underline;
       }
 
-      /* Headings — !important to override Cayman theme green */
       h1, h2, h3, h4, h5, h6 {
-        font-family: "Times New Roman", Times, serif !important;
-        color: #000000 !important;
+        font-family: inherit !important;
+        color: #212324 !important;
         font-weight: bold;
         margin-top: 1.4em;
         margin-bottom: 0.4em;
       }
 
-      /* Section break: grey bar above h2 */
       h2 {
-        border-top: 1px solid #d0d0d0;
+        border-top: 1px solid #c1c5c7;
         padding-top: 0.9em;
         margin-top: 2em;
       }
 
-      /* First h2 on a page doesn't need a top bar */
       h2:first-of-type {
         border-top: none;
         padding-top: 0;
         margin-top: 1.4em;
       }
 
-      /* Style <hr> as a light grey bar */
       hr {
         border: none;
-        border-top: 1px solid #d0d0d0;
+        border-top: 1px solid #c1c5c7;
         margin: 2em 0;
       }
 
-      /* Override Cayman theme page-header */
-      .page-header {
-        display: none;
-      }
+      /* Hide Cayman's built-in page header */
+      .page-header { display: none; }
 
       /* Navigation bar */
       .top-bar {
@@ -76,54 +72,49 @@
         justify-content: space-between;
         align-items: center;
         padding: 16px 48px;
-        background-color: #ffffff00;
-        border-bottom: 1px solid #cccccc;
-        font-family: "Times New Roman", Times, serif;
+        background-color: #828a8f;
+        border-bottom: 1px solid #61686b;
       }
 
       .top-bar .site-name {
         font-size: 1.15em;
         font-weight: bold;
-        color: #000000;
+        color: #f2f3f4;
         letter-spacing: 0.01em;
       }
 
       .top-bar nav a {
-        color: #0000cc;
+        color: #f2f3f4;
         text-decoration: none;
         margin-left: 32px;
         font-size: 1em;
       }
 
       .top-bar nav a:hover {
+        color: #ffffff;
         text-decoration: underline;
       }
 
-      /* Main content area */
+      /* Main content */
       main {
         padding: 48px 24px;
         max-width: 860px;
         margin: 0 auto;
-        font-family: "Times New Roman", Times, serif;
-        color: #000000;
       }
 
       /* Footer */
       .site-footer {
-        font-family: "Times New Roman", Times, serif;
-        color: #000000;
-        border-top: 1px solid #cccccc;
+        color: #61686b;
+        border-top: 1px solid #c1c5c7;
         padding-top: 20px;
         margin-top: 60px;
         text-align: center;
         font-size: 0.9em;
       }
 
-      .site-footer a {
-        color: #0000cc;
-      }
+      .site-footer a { color: #414548; }
 
-      /* Skip to content */
+      /* Skip link (accessibility) */
       #skip-to-content {
         position: absolute;
         left: -9999px;
@@ -133,9 +124,9 @@
         left: 0;
         top: 0;
         padding: 4px 8px;
-        background: #ffffff3e;
-        color: #0000cc;
-        border: 1px solid #0000cc;
+        background: #828a8f;
+        color: #f2f3f4;
+        border: 1px solid #414548;
         z-index: 1000;
       }
     </style>
@@ -162,11 +153,11 @@
           <a href="mailto:theo.drossidis@gmail.com">theo.drossidis@gmail.com</a>
         </p>
         <p>
-          <a href="https://github.com/yourusername" target="_blank" style="margin-right: 10px;">
-            <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/github.svg" alt="GitHub" style="width: 20px; vertical-align: middle;">
+          <a href="https://github.com/TheoDros95" target="_blank" style="margin-right: 10px;">
+            <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/github.svg" alt="GitHub" style="width: 20px; vertical-align: middle; opacity: 0.55;">
           </a>
           <a href="https://www.linkedin.com/in/theo-drossidis-5625121ba" target="_blank">
-            <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/linkedin.svg" alt="LinkedIn" style="width: 20px; vertical-align: middle;">
+            <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/linkedin.svg" alt="LinkedIn" style="width: 20px; vertical-align: middle; opacity: 0.55;">
           </a>
         </p>
       </footer>


### PR DESCRIPTION
## Summary

- Replace all colors with a cohesive grey palette derived from base **#828a8f** (RGB 130 138 143)
  - Page background: `#f2f3f4` (lightest tint)
  - Borders/dividers: `#c1c5c7` (medium tint)
  - Nav bar: `#828a8f` (base) with `#f2f3f4` text
  - Body text/headings: `#212324` (darkest shade)
  - Content links: `#414548` (dark shade)
  - Footer text: `#61686b` (medium shade)
- Remove dead `{% include head-custom.html %}` — file never existed in the repo
- Fix broken placeholder GitHub link (`yourusername` → `TheoDros95`)
- Remove accidental semi-transparent color values (`#ffffff80`, `#ffffff00`, `#ffffff3e`)
- Consolidate redundant `font-family` declarations via `body` inheritance

## Test plan

- [ ] Nav bar shows in base grey (`#828a8f`) with light text
- [ ] Page background is light grey (`#f2f3f4`), not pure white
- [ ] All links render in dark grey (not blue)
- [ ] Headings and body text in darkest shade (`#212324`)
- [ ] Footer social icons visible and tinted grey

🤖 Generated with [Claude Code](https://claude.com/claude-code)